### PR TITLE
Usage: replace .parent access with a stack of parent nodes 

### DIFF
--- a/util/util.ts
+++ b/util/util.ts
@@ -302,10 +302,9 @@ export function isFunctionScopeBoundary(node: ts.Node): boolean {
     }
 }
 
-export function isBlockScopeBoundary(node: ts.Node): boolean {
+export function isBlockScopeBoundary(node: ts.Node, parent = node.parent!): boolean {
     switch (node.kind) {
         case ts.SyntaxKind.Block:
-            const parent = node.parent!;
             return parent.kind !== ts.SyntaxKind.CatchClause &&
                    // blocks inside SourceFile are block scope boundaries
                    (parent.kind === ts.SyntaxKind.SourceFile ||


### PR DESCRIPTION
I'm trying to use `collectVariableUsage` in a custom transformer, but ran into problems because synthesized nodes don't have a parent property (by design - https://github.com/Microsoft/TypeScript/issues/16891). This replaces all parent access with a passed-around stack of parents.
