### PR TITLE
usage: Handle ConditionalTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nyc": "^11.4.1",
     "tslint": "^5.8.0",
     "tslint-consistent-codestyle": "^1.11.0",
-    "typescript": "~2.7.1"
+    "typescript": "^2.8.0-dev.20180302"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nyc": "^11.4.1",
     "tslint": "^5.8.0",
     "tslint-consistent-codestyle": "^1.11.0",
-    "typescript": "^2.8.0-dev.20180302"
+    "typescript": "2.8.0-dev.20180302"
   },
   "peerDependencies": {
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"

--- a/test/rules/usage/conditional-type.ts.lint
+++ b/test/rules/usage/conditional-type.ts.lint
@@ -1,0 +1,29 @@
+type T = any;
+     ~ [Unused]
+type U<T, U, V, W> = Map<T, U> | ReadonlyMap<V, W>;
+type V = any;
+     ~ [Unused]
+type W = any;
+type X = any;
+
+type C<T> = T extends U<infer V, infer W, infer X, infer W> & W ? V : X;
+     ~ [Unused]
+                                       ~ [Unused]
+                                                ~ [Unused]
+                                                         ~ [Unused]
+
+type A<T> = T;
+type C2<T> = T extends A<infer A> ? A ? never;
+     ~~ [Unused]
+
+type C3<T, V> = T extends Array<infer V> ? V : never;
+     ~~ [Unused]
+           ~ [Unused]
+
+type C4<T> = T extends Array<infer T> ? any : never;
+     ~~ [Unused]
+                                   ~ [Unused]
+
+type C5<T, U> = T extends (U extends Array<infer T> ? U : T) ? T : never;
+     ~~ [Unused]
+                                                 ~ [Unused]

--- a/util/util.ts
+++ b/util/util.ts
@@ -323,6 +323,7 @@ export function isFunctionScopeBoundary(node: ts.Node): boolean {
         case ts.SyntaxKind.ConstructorType:
         case ts.SyntaxKind.FunctionType:
         case ts.SyntaxKind.MappedType:
+        case ts.SyntaxKind.ConditionalType:
             return true;
         case ts.SyntaxKind.SourceFile:
             // if SourceFile is no module, it contributes to the global scope and is therefore no scope boundary


### PR DESCRIPTION
Add a new Scope subclass for ConditionalTypes. `infer T` is handled like any other TypeParameterDeclaration, so they don't need special handling.
InferTypes can only be referenced in the true branch of the ConditionalType. Every other reference to the same name references a type in a parent scope.