### PR TITLE
Make "isThenable" check more precise.

### DIFF
--- a/util/type.ts
+++ b/util/type.ts
@@ -104,7 +104,8 @@ export function isThenableType(checker: ts.TypeChecker, node: ts.Node, type = ch
         const thenType = checker.getTypeOfSymbolAtLocation(then, node);
         for (const t of unionTypeParts(thenType))
             for (const signature of t.getCallSignatures())
-                if (signature.parameters.length !== 0 && isCallback(checker, signature.parameters[0], node))
+              if (signature.parameters.length !== 0 && signature.typeParameters !== undefined &&
+                signature.typeParameters.length !== 0 && isCallback(checker, signature.parameters[0], node))
                     return true;
     }
     return false;


### PR DESCRIPTION
We use `isThenable` to decide if something should be awaited. The use case is very much similar to https://github.com/fimbullinter/wotan/blob/master/packages/mimir/docs/await-async-result.md#await-async-result. We run into a class that defines a `then` method accidentally but it's actually not a `Promise` and should not be awaited.

I'm not sure how to better distinguish a `Promise.then` and an accidental `foo.then`. Looking at the `Promise` interface https://github.com/Microsoft/TypeScript/blob/v3.3.1/lib/lib.es5.d.ts#L1406, I'm trying to add a heuristic that if the `then()` is non-generic it's probably unrelated to `Promise`.
Another idea is to check that property `catch` is also defined.

I would appreciate any ideas.