### PR TITLE
add utilities to detect readonly-ness of symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 npm-debug.log
 /coverage/
 /.nyc_output
+!/test/rules/*/*.js
+/test/rules/*/*Rule.js

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tslint": "^5.8.0",
     "tslint-consistent-codestyle": "^1.11.0",
     "ttypescript": "^1.5.5",
-    "typescript": "^3.4.1"
+    "typescript": "^3.4.5"
   },
   "peerDependencies": {
     "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev"

--- a/test/rules/readonly/prop.js
+++ b/test/rules/readonly/prop.js
@@ -1,0 +1,10 @@
+export let p = Math.random();
+
+export let jsObj = {};
+Object.defineProperty(jsObj, 'a', {value: 1, writable: false});
+Object.defineProperty(jsObj, 'b', {get() { return 1; }});
+Object.defineProperty(jsObj, 'c', {get() { return 1; }, set(_) {}});
+Object.defineProperty(jsObj, 'd', {value: 1});
+Object.defineProperty(jsObj, 'e', {value: 1, writable: true});
+const descriptor = {value: 1, writable: false};
+Object.defineProperty(jsObj, 'f', descriptor);

--- a/test/rules/readonly/test.ts.lint
+++ b/test/rules/readonly/test.ts.lint
@@ -1,5 +1,5 @@
-import {jsObj} from './js';
-import * as namespaceImport from './js';
+import {jsObj} from './prop';
+import * as namespaceImport from './prop';
 
 declare function get<T>(): T;
 

--- a/test/rules/readonly/test.ts.lint
+++ b/test/rules/readonly/test.ts.lint
@@ -1,0 +1,123 @@
+import {jsObj} from './js';
+import * as namespaceImport from './js';
+
+declare function get<T>(): T;
+
+type Mutable<T> = {
+    -readonly [K in keyof T]: T[K];
+}
+type ReadonlyPick<T, K extends keyof T> = {
+    readonly [P in K]: T[P]
+}
+type P = {p: number};
+type RP = {readonly p: number};
+
+const constObj = {p: Number()} as const;
+const getOnly = {
+    get p() { return 1; }
+};
+const getSet = {
+    get p() { return 1; },
+    set p(_) {},
+};
+
+namespace ns {
+    export const p = Number();
+}
+class C {
+    readonly p = Number();
+}
+const prop = Symbol();
+class SymbolName {
+    [prop]: number;
+}
+class SymbolNameReadonly {
+    readonly [prop]: number;
+}
+enum E {
+    p = 1;
+}
+
+get<RP>().p = 1;
+          ~      [readonly]
+get<Readonly<P>>().p = 1;
+                   ~      [readonly]
+get<Partial<Readonly<P>>>().p = 1;
+                            ~      [readonly]
+get<Mutable<RP>>().p = 1;
+get<Pick<Readonly<Record<string, number>>, 'p'>>().p = 1;
+get<ReadonlyPick<Record<string, number>, 'p'>>().p = 1;
+                                                 ~      [readonly]
+get<{readonly [x: string]: number} | P>().p = 1;
+                                          ~      [readonly]
+get<{readonly [x: string]: number; p: number}>().p = 1;
+get<{[x: string]: number; readonly p: number}>().p = 1;
+                                                 ~      [readonly]
+get<readonly [] & {1: number}>()[1] = 1;
+get<readonly [number] & {1: number}>()[1] = 1;
+get<readonly [number, number] & {1: number}>()[1] = 1;
+                                               ~       [readonly '1']
+get<readonly [number, ...number[]] & {1: number}>()[1] = 1;
+get<readonly [...number[]] & {1: number}>()[1] = 1;
+get<readonly [number, ...number[]] | {1: number}>()[1] = 1;
+                                                    ~       [readonly '1']
+get<readonly [...number[]] | {1: number}>()[1] = 1;
+                                            ~       [readonly '1']
+constObj.p = 1;
+         ~      [readonly]
+ns.p = 1;
+   ~      [readonly]
+jsObj.a = 1;
+      ~      [readonly]
+jsObj.b = 1;
+      ~      [readonly]
+jsObj.c = 1;
+jsObj.d = 1;
+jsObj.e = 1;
+jsObj.f = 1;
+      ~      [readonly]
+namespaceImport.p = 1;
+get<Mutable<typeof constObj>>().p = 1;
+get<Mutable<typeof ns>>().p = 1;
+get<Mutable<typeof namespaceImport>>().p = 1;
+getOnly.p = 1;
+        ~      [readonly]
+getSet.p = 1;
+get<Mutable<typeof getOnly>>().p = 1;
+get<Readonly<typeof getSet>>().p = 1;
+                               ~      [readonly]
+get<P | Pick<Readonly<Record<'p' | 'q', number>>, 'q'> & P>().p = 1;
+get<Record<string, number>>().p = 1;
+get<Pick<{readonly [K: string]: number} | {x: number}, 'x'>>().x = 1; //
+                                                               ~         [readonly]
+get<Pick<{p: number} | {readonly [p: string]: number}, 'p'>>().p = 1; //
+                                                               ~         [readonly]
+get<Pick<readonly [number, number], 1>>()[1] = 1;
+                                          ~       [readonly '1']
+new C().p = 1;
+        ~      [readonly]
+get<Mutable<C>>().p = 1;
+get<{[Symbol.toStringTag]: string}>()[Symbol.toStringTag] = '1';
+get<{readonly [Symbol.toStringTag]: string}>()[Symbol.toStringTag] = '1';
+                                               ~~~~~~~~~~~~~~~~~~         [readonly '[Symbol.toStringTag]']
+get<Readonly<{[Symbol.toStringTag]: string}>>()[Symbol.toStringTag] = '1';
+get<{readonly __p: number, ___p: number}>().__p = 1;
+                                            ~~~      [readonly]
+get<{readonly __p: number, ___p: number}>().___p = 1;
+new SymbolName()[prop] = 1;
+new SymbolNameReadonly()[prop] = 1;
+                         ~~~~       [readonly '[prop]']
+get<Readonly<SymbolName>>()[prop] = 1;
+                            ~~~~       [readonly '[prop]']
+get<Mutable<SymbolNameReadonly>>()[prop] = 1;
+get<{readonly [x: string]: number; [x: number]: number} | P>().p = 1;
+                                                               ~      [readonly]
+get<{readonly [x: string]: number; [x: number]: number} | [number]>()[0] = 1;
+get<{[x: string]: number; readonly [x: number]: number} | P>().p = 1;
+get<{[x: string]: number; readonly [x: number]: number} | [number]>()[0] = 1;
+                                                                      ~       [readonly '0']
+get<{readonly [x: string]: number} | [number]>()[0] = 1;
+                                                 ~       [readonly '0']
+E.p = 1;
+  ~      [readonly]
+get<Mutable<typeof E>>().p = 1;

--- a/test/rules/readonly/testReadonlyRule.ts
+++ b/test/rules/readonly/testReadonlyRule.ts
@@ -13,8 +13,6 @@ function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
     return ts.forEachChild(ctx.sourceFile, function cb(node): void {
         if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
             const {left} = node;
-            if (ts.isPropertyAccessExpression(left) && left.name.text === 'x')
-                debugger;
             if (
                 ts.isPropertyAccessExpression(left) &&
                 isPropertyReadonlyInType(checker.getTypeAtLocation(left.expression), left.name.escapedText, checker)

--- a/test/rules/readonly/testReadonlyRule.ts
+++ b/test/rules/readonly/testReadonlyRule.ts
@@ -1,0 +1,69 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import { isPropertyReadonlyInType, unionTypeParts } from '../../../util'
+import { isLiteralType, isUniqueESSymbolType } from '../../../typeguard/type';
+
+export class Rule extends Lint.Rules.TypedRule {
+    public applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program) {
+        return this.applyWithFunction(sourceFile, walk, undefined, program.getTypeChecker());
+    }
+}
+
+function walk(ctx: Lint.WalkContext<void>, checker: ts.TypeChecker) {
+    return ts.forEachChild(ctx.sourceFile, function cb(node): void {
+        if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+            const {left} = node;
+            if (ts.isPropertyAccessExpression(left) && left.name.text === 'x')
+                debugger;
+            if (
+                ts.isPropertyAccessExpression(left) &&
+                isPropertyReadonlyInType(checker.getTypeAtLocation(left.expression), left.name.escapedText, checker)
+            ) {
+                ctx.addFailureAtNode(left.name, 'readonly');
+            } else if (ts.isElementAccessExpression(left)) {
+                const baseType = checker.getTypeAtLocation(left.expression);
+                for (const symbol of lateBoundPropertyNames(left.argumentExpression, checker).properties) {
+                    if (isPropertyReadonlyInType(baseType, symbol.symbolName, checker)) {
+                        ctx.addFailureAtNode(left.argumentExpression, `readonly '${symbol.name}'`);
+                    }
+                }
+            }
+        }
+        return ts.forEachChild(node, cb);
+    });
+}
+
+// TODO make proper utility function
+function lateBoundPropertyNames(node: ts.Expression, checker: ts.TypeChecker) {
+    let known = true;
+    const properties: Array<{name: string, symbolName: ts.__String}> = [];
+    if (
+        ts.isPropertyAccessExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'Symbol'
+    ) {
+        properties.push({
+            name: `[Symbol.${node.name.text}]`,
+            symbolName: <ts.__String>`__@${node.name.text}`,
+        });
+    } else {
+        const type = checker.getTypeAtLocation(node)!;
+        for (const key of unionTypeParts(checker.getBaseConstraintOfType(type) || type)) {
+            if (isLiteralType(key)) {
+                const name = String(key.value);
+                properties.push({
+                    name,
+                    symbolName: ts.escapeLeadingUnderscores(name),
+                });
+            } else if (isUniqueESSymbolType(key)){
+                properties.push({
+                    name: `[${key.symbol.name}]`,
+                    symbolName: key.escapedName,
+                });
+            } else {
+                known = false;
+            }
+        }
+    }
+    return {known, properties};
+}

--- a/test/rules/readonly/tsconfig.json
+++ b/test/rules/readonly/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "allowJs": true,
+    "checkJs": true,
+    "moduleResolution": "node"
+  }
+}

--- a/test/rules/readonly/tslint.json
+++ b/test/rules/readonly/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": ".",
+  "rules": {
+    "test-readonly": true
+  }
+}

--- a/typeguard/2.8/node.ts
+++ b/typeguard/2.8/node.ts
@@ -505,6 +505,19 @@ export function isNumericLiteral(node: ts.Node): node is ts.NumericLiteral {
     return node.kind === ts.SyntaxKind.NumericLiteral;
 }
 
+export function isNumericOrStringLikeLiteral(
+    node: ts.Node,
+): node is ts.NumericLiteral | ts.StringLiteral | ts.NoSubstitutionTemplateLiteral {
+    switch (node.kind) {
+        case ts.SyntaxKind.StringLiteral:
+        case ts.SyntaxKind.NumericLiteral:
+        case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+            return true;
+        default:
+            return false;
+    }
+}
+
 export function isObjectBindingPattern(node: ts.Node): node is ts.ObjectBindingPattern {
     return node.kind === ts.SyntaxKind.ObjectBindingPattern;
 }

--- a/typeguard/3.0/type.ts
+++ b/typeguard/3.0/type.ts
@@ -1,7 +1,12 @@
 export * from '../2.9/type';
 
 import * as ts from 'typescript';
+import { isTypeReference } from '../3.2';
 
 export function isTupleType(type: ts.Type): type is ts.TupleType {
     return (type.flags & ts.TypeFlags.Object && (<ts.ObjectType>type).objectFlags & ts.ObjectFlags.Tuple) !== 0;
+}
+
+export function isTupleTypeReference(type: ts.Type): type is ts.TypeReference & {target: ts.TupleType} {
+    return isTypeReference(type) && isTupleType(type.target);
 }

--- a/util/type.ts
+++ b/util/type.ts
@@ -17,7 +17,13 @@ import {
     isNodeFlagSet,
     isNumericPropertyName,
 } from './util';
-import { isPropertyAssignment, isVariableDeclaration, isCallExpression, isShorthandPropertyAssignment } from '../typeguard/node';
+import {
+    isPropertyAssignment,
+    isVariableDeclaration,
+    isCallExpression,
+    isShorthandPropertyAssignment,
+    isEnumMember,
+} from '../typeguard/node';
 
 export function isEmptyObjectType(type: ts.Type): type is ts.ObjectType {
     if (isObjectType(type) &&
@@ -169,17 +175,27 @@ export function getPropertyOfType(type: ts.Type, name: ts.__String) {
     return type.getProperties().find((s) => s.escapedName === name);
 }
 
-/** Determines if writing to a certain property of a given type is allowed. If the property is not present, index signatures are checked. */
-export function isPropertyReadonlyInType(type: ts.Type, name: ts.__String, checker: ts.TypeChecker) {
-    return someTypePart(type, isUnionType, (t) => {
+/** Determines if writing to a certain property of a given type is allowed. */
+export function isPropertyReadonlyInType(type: ts.Type, name: ts.__String, checker: ts.TypeChecker): boolean {
+    let seenProperty = false;
+    let seenReadonlySignature = false;
+    for (const t of unionTypeParts(type)) {
         if (getPropertyOfType(t, name) === undefined) {
             // property is not present in this part of the union -> check for readonly index signature
             const index = (isNumericPropertyName(name) ? checker.getIndexInfoOfType(t, ts.IndexKind.Number) : undefined) ||
                 checker.getIndexInfoOfType(t, ts.IndexKind.String);
-            return index !== undefined && index.isReadonly;
+            if (index !== undefined && index.isReadonly) {
+                if (seenProperty)
+                    return true;
+                seenReadonlySignature = true;
+            }
+        } else if (seenReadonlySignature || isReadonlyPropertyIntersection(t, name, checker)) {
+            return true;
+        } else {
+            seenProperty = true;
         }
-        return isReadonlyPropertyIntersection(t, name, checker);
-    });
+    }
+    return false;
 }
 
 function isReadonlyPropertyIntersection(type: ts.Type, name: ts.__String, checker: ts.TypeChecker) {
@@ -188,8 +204,8 @@ function isReadonlyPropertyIntersection(type: ts.Type, name: ts.__String, checke
         if (prop === undefined)
             return false;
         if (prop.flags &  ts.SymbolFlags.Transient) {
-            if (/^(?:[1-9]\d*|0)$/.test(<string>name) && isElementOfReadonlyTuple(t, name))
-                return true;
+            if (/^(?:[1-9]\d*|0)$/.test(<string>name) && isTupleTypeReference(t))
+                return t.target.readonly;
             switch (isReadonlyPropertyFromMappedType(t, name, checker)) {
                 case true:
                     return true;
@@ -208,16 +224,12 @@ function isReadonlyPropertyIntersection(type: ts.Type, name: ts.__String, checke
     });
 }
 
-function isElementOfReadonlyTuple(type: ts.Type, name: ts.__String): boolean {
-    // TODO might change: https://github.com/microsoft/TypeScript/issues/31481
-    return isTupleTypeReference(type) && type.target.readonly && getPropertyOfType(type.target, name) !== undefined;
-}
-
 function isReadonlyPropertyFromMappedType(type: ts.Type, name: ts.__String, checker: ts.TypeChecker): boolean | undefined {
     if (!isObjectType(type) || !isObjectFlagSet(type, ts.ObjectFlags.Mapped))
         return;
     const declaration = <ts.MappedTypeNode>type.symbol!.declarations![0];
-    if (declaration.readonlyToken !== undefined)
+    // well-known symbols are not affected by mapped types
+    if (declaration.readonlyToken !== undefined && !/^__@[^@]+$/.test(<string>name))
         return declaration.readonlyToken.kind !== ts.SyntaxKind.MinusToken;
     return isPropertyReadonlyInType((<{modifiersType: ts.Type}><unknown>type).modifiersType, name, checker);
 }
@@ -229,6 +241,7 @@ export function symbolHasReadonlyDeclaration(symbol: ts.Symbol, checker: ts.Type
             isModifierFlagSet(node, ts.ModifierFlags.Readonly) ||
             isVariableDeclaration(node) && isNodeFlagSet(node.parent!, ts.NodeFlags.Const) ||
             isCallExpression(node) && isReadonlyAssignmentDeclaration(node, checker) ||
+            isEnumMember(node) ||
             (isPropertyAssignment(node) || isShorthandPropertyAssignment(node)) && isInConstContext(node.parent!),
         );
 }

--- a/util/type.ts
+++ b/util/type.ts
@@ -1,6 +1,23 @@
 import * as ts from 'typescript';
-import { isTypeParameter, isUnionType, isIntersectionType, isLiteralType, isObjectType } from '../typeguard/type';
-import { isTypeFlagSet } from './util';
+import {
+    isTypeParameter,
+    isUnionType,
+    isIntersectionType,
+    isLiteralType,
+    isObjectType,
+    isTupleTypeReference,
+} from '../typeguard/type';
+import {
+    isTypeFlagSet,
+    isReadonlyAssignmentDeclaration,
+    isInConstContext,
+    isObjectFlagSet,
+    isSymbolFlagSet,
+    isModifierFlagSet,
+    isNodeFlagSet,
+    isNumericPropertyName,
+} from './util';
+import { isPropertyAssignment, isVariableDeclaration, isCallExpression, isShorthandPropertyAssignment } from '../typeguard/node';
 
 export function isEmptyObjectType(type: ts.Type): type is ts.ObjectType {
     if (isObjectType(type) &&
@@ -92,6 +109,15 @@ export function unionTypeParts(type: ts.Type): ts.Type[] {
     return isUnionType(type) ? type.types : [type];
 }
 
+/** Returns all types of a intersection type or an array containing `type` itself if it's no intersection type. */
+export function intersectionTypeParts(type: ts.Type): ts.Type[] {
+    return isIntersectionType(type) ? type.types : [type];
+}
+
+export function someTypePart(type: ts.Type, predicate: (t: ts.Type) => t is ts.UnionOrIntersectionType, cb: (t: ts.Type) => boolean) {
+    return predicate(type) ? type.types.some(cb) : cb(type);
+}
+
 /** Determines if a type thenable and can be used with `await`. */
 export function isThenableType(checker: ts.TypeChecker, node: ts.Node, type: ts.Type): boolean;
 /** Determines if a type thenable and can be used with `await`. */
@@ -136,5 +162,73 @@ export function isFalsyType(type: ts.Type): boolean {
 /** Determines whether the given type is a boolean literal type and matches the given boolean literal (true or false). */
 export function isBooleanLiteralType(type: ts.Type, literal: boolean) {
     return isTypeFlagSet(type, ts.TypeFlags.BooleanLiteral) &&
-        (<{intrinsicName: string}><{}>type).intrinsicName === (literal ? 'true' : 'false');
+    (<{intrinsicName: string}><{}>type).intrinsicName === (literal ? 'true' : 'false');
+}
+
+export function getPropertyOfType(type: ts.Type, name: ts.__String) {
+    return type.getProperties().find((s) => s.escapedName === name);
+}
+
+/** Determines if writing to a certain property of a given type is allowed. If the property is not present, index signatures are checked. */
+export function isPropertyReadonlyInType(type: ts.Type, name: ts.__String, checker: ts.TypeChecker) {
+    return someTypePart(type, isUnionType, (t) => {
+        if (getPropertyOfType(t, name) === undefined) {
+            // property is not present in this part of the union -> check for readonly index signature
+            const index = (isNumericPropertyName(name) ? checker.getIndexInfoOfType(t, ts.IndexKind.Number) : undefined) ||
+                checker.getIndexInfoOfType(t, ts.IndexKind.String);
+            return index !== undefined && index.isReadonly;
+        }
+        return isReadonlyPropertyIntersection(t, name, checker);
+    });
+}
+
+function isReadonlyPropertyIntersection(type: ts.Type, name: ts.__String, checker: ts.TypeChecker) {
+    return someTypePart(type, isIntersectionType, (t) => {
+        const prop = getPropertyOfType(t, name);
+        if (prop === undefined)
+            return false;
+        if (prop.flags &  ts.SymbolFlags.Transient) {
+            if (/^(?:[1-9]\d*|0)$/.test(<string>name) && isElementOfReadonlyTuple(t, name))
+                return true;
+            switch (isReadonlyPropertyFromMappedType(t, name, checker)) {
+                case true:
+                    return true;
+                case false:
+                    return false;
+                default:
+                    // `undefined` falls through
+            }
+        }
+        return (
+            // members of namespace import
+            isSymbolFlagSet(prop, ts.SymbolFlags.ValueModule) ||
+            // we unwrapped every mapped type, now we can check the actual declarations
+            symbolHasReadonlyDeclaration(prop, checker)
+        );
+    });
+}
+
+function isElementOfReadonlyTuple(type: ts.Type, name: ts.__String): boolean {
+    // TODO might change: https://github.com/microsoft/TypeScript/issues/31481
+    return isTupleTypeReference(type) && type.target.readonly && getPropertyOfType(type.target, name) !== undefined;
+}
+
+function isReadonlyPropertyFromMappedType(type: ts.Type, name: ts.__String, checker: ts.TypeChecker): boolean | undefined {
+    if (!isObjectType(type) || !isObjectFlagSet(type, ts.ObjectFlags.Mapped))
+        return;
+    const declaration = <ts.MappedTypeNode>type.symbol!.declarations![0];
+    if (declaration.readonlyToken !== undefined)
+        return declaration.readonlyToken.kind !== ts.SyntaxKind.MinusToken;
+    return isPropertyReadonlyInType((<{modifiersType: ts.Type}><unknown>type).modifiersType, name, checker);
+}
+
+function symbolHasReadonlyDeclaration(symbol: ts.Symbol, checker: ts.TypeChecker) {
+    return (symbol.flags & ts.SymbolFlags.Accessor) === ts.SymbolFlags.GetAccessor ||
+        symbol.declarations !== undefined &&
+        symbol.declarations.some((node) =>
+            isModifierFlagSet(node, ts.ModifierFlags.Readonly) ||
+            isVariableDeclaration(node) && isNodeFlagSet(node.parent!, ts.NodeFlags.Const) ||
+            isCallExpression(node) && isReadonlyAssignmentDeclaration(node, checker) ||
+            (isPropertyAssignment(node) || isShorthandPropertyAssignment(node)) && isInConstContext(node.parent!),
+        );
 }

--- a/util/type.ts
+++ b/util/type.ts
@@ -222,7 +222,7 @@ function isReadonlyPropertyFromMappedType(type: ts.Type, name: ts.__String, chec
     return isPropertyReadonlyInType((<{modifiersType: ts.Type}><unknown>type).modifiersType, name, checker);
 }
 
-function symbolHasReadonlyDeclaration(symbol: ts.Symbol, checker: ts.TypeChecker) {
+export function symbolHasReadonlyDeclaration(symbol: ts.Symbol, checker: ts.TypeChecker) {
     return (symbol.flags & ts.SymbolFlags.Accessor) === ts.SymbolFlags.GetAccessor ||
         symbol.declarations !== undefined &&
         symbol.declarations.some((node) =>

--- a/util/util.ts
+++ b/util/util.ts
@@ -1439,7 +1439,7 @@ export interface WellKnownSymbolLiteral extends ts.PropertyAccessExpression {
 export function isWellKnownSymbolLiterally(node: ts.Expression): node is WellKnownSymbolLiteral  {
     return ts.isPropertyAccessExpression(node) &&
     ts.isIdentifier(node.expression) &&
-    node.expression.text === 'Symbol';
+    node.expression.escapedText === 'Symbol';
 }
 
 export interface PropertyName {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,10 +2906,10 @@ type-detect@^4.0.0:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
-  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
+typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.5.3"


### PR DESCRIPTION
This is a workaround for https://github.com/microsoft/TypeScript/issues/31296. It correctly handles mapped types, readonly tuples, index signatures, const contexts, enum members, namespace imports, get-only properties, readonly properties (also via Object.defineProperty) and const namespace exports.

* isNumericOrStringLikeLiteral
* isTupleTypeReference
* intersectionTypeParts
* someTypePart
* getPropertyOfType
* **isPropertyReadonlyInType**
* **symbolHasReadonlyDeclaration**
* isNumericPropertyName
* isReadonlyAssignmentDeclaration
* isBindableObjectDefinePropertyCall
* getLateBoundPropertyNames
* getPropertyNameFromType
* isWellKnownSymbolLiterally
* getPropertyNameOfWellKnownSymbol
* unwrapParentheses

@CSchulz if you are still trying to get your lint rule to work, this might be of interest for you.