### PR TITLE
Make typescript optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
   "peerDependencies": {
     "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "tslib": "^1.8.1"
   },


### PR DESCRIPTION
This is to prevent warning when tsutils is required by other packages as optional dependency, for example: `warning "prettierx > @typescript-eslint/typescript-estree > tsutils@3.17.1" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".`