### PR TITLE
Remove old dev versions from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "4.2.0-dev.20201230"
   },
   "peerDependencies": {
-    "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+    "typescript": ">=2.8.0"
   },
   "dependencies": {
     "tslib": "^1.8.1"


### PR DESCRIPTION
There's no compelling reason to be using an old development version anymore. Removing them greatly simplifies the expression