### PR TITLE
Added check for modifiersType existing in a mapped type

### DIFF
--- a/util/type.ts
+++ b/util/type.ts
@@ -291,9 +291,8 @@ function isReadonlyPropertyFromMappedType(type: ts.Type, name: ts.__String, chec
     if (declaration.readonlyToken !== undefined && !/^__@[^@]+$/.test(<string>name))
         return declaration.readonlyToken.kind !== ts.SyntaxKind.MinusToken;
 
-    if (!hasModifiersType(type)) {
+    if (!hasModifiersType(type))
         return;
-    }
 
     return isPropertyReadonlyInType((<{modifiersType: ts.Type}><unknown>type).modifiersType, name, checker);
 }

--- a/util/type.ts
+++ b/util/type.ts
@@ -279,6 +279,10 @@ function isReadonlyPropertyIntersection(type: ts.Type, name: ts.__String, checke
     });
 }
 
+function hasModifiersType(type: ts.Type): type is ts.Type & { modifiersType: ts.Type} {
+    return 'modifiersType' in type;
+}
+
 function isReadonlyPropertyFromMappedType(type: ts.Type, name: ts.__String, checker: ts.TypeChecker): boolean | undefined {
     if (!isObjectType(type) || !isObjectFlagSet(type, ts.ObjectFlags.Mapped))
         return;
@@ -286,6 +290,11 @@ function isReadonlyPropertyFromMappedType(type: ts.Type, name: ts.__String, chec
     // well-known symbols are not affected by mapped types
     if (declaration.readonlyToken !== undefined && !/^__@[^@]+$/.test(<string>name))
         return declaration.readonlyToken.kind !== ts.SyntaxKind.MinusToken;
+
+    if (!hasModifiersType(type)) {
+        return;
+    }
+
     return isPropertyReadonlyInType((<{modifiersType: ts.Type}><unknown>type).modifiersType, name, checker);
 }
 


### PR DESCRIPTION
Fixes https://github.com/typescript-eslint/typescript-eslint/issues/3405

The issue is that `modifiersType` doesn't necessarily exist in TypeScript's internal `MappedType`:

https://github.com/microsoft/TypeScript/blob/5fde87135f25a2dbea8a98e05438e61fdad06fe6/src/compiler/types.ts#L5431

```ts
/* @internal */
export interface MappedType extends AnonymousType {
    // ...
    modifiersType?: Type;
    // ...
}
```

Co-authored-by: @kirjs