### PR TITLE
Allow tslib v2 as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   },
   "dependencies": {
-    "tslib": "^1.8.1"
+    "tslib": "^1.8.1 || ^2.0.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
I'm upgrading typescript-eslint with typescript v4, but the tslib under tsutils is always installed as 1.x which is unable to work with typescript v4.3. Array spreading syntax is broken while building. 

#### error messgae
> This syntax requires an imported helper named '__spreadArray' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'`