### PR TITLE
make typescript peer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
   "peerDependencies": {
     "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "tslib": "^1.8.1"
   },


### PR DESCRIPTION
This will eliminate warnings of missing peer dependencies when libraries like e.g. `eslint-plugin-jest` are used in a non typescript project.

```
 WARN  Issues with peer dependencies found
└─┬ eslint-plugin-jest 27.0.4
  └─┬ @typescript-eslint/utils 5.37.0
    └─┬ @typescript-eslint/typescript-estree 5.37.0
      └─┬ tsutils 3.21.0
        └── ✕ missing peer typescript@">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
Peer dependencies that should be installed:
  typescript@>=2.8.0  
```

resolves #143 